### PR TITLE
2ping: fix 'use of uninitialized' warning

### DIFF
--- a/script/2ping.in
+++ b/script/2ping.in
@@ -350,7 +350,8 @@ if($opt_listen) {
   foreach my $opt_intaddr (@working_opt_intaddrs) {
     my($sock);
     my($is_ipv6) = $opt_ipv6;
-    if($opt_ipv6 && $opt_intaddr =~ /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/) {
+    if($opt_ipv6 && defined $opt_intaddr &&
+		$opt_intaddr =~ /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/) {
       $is_ipv6 = 0;
     }
     my $sockerr = '';


### PR DESCRIPTION
With 2ping --listen -6, I see
Use of uninitialized value $opt_intaddr in pattern match (m//) at /usr/bin/2ping line 356.
Check for undef, as there might be one pushed to the array.

Signed-off-by: Jiri Slaby <jirislaby@gmail.com>