### PR TITLE
Install manpage and bump python to 3.10+

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It uses 3-way pings (akin to TCP SYN, SYN/ACK, ACK) and after-the-fact state com
 
 ## Installation
 
-2ping requires Python 3 version 3.6 or higher.
+2ping requires Python 3 version 3.10 or higher.
 
 To install 2ping with all optional dependencies as a pipx package:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ full = [
     "pycryptodomex",
 ]
 
+[tool.setuptools.data-files]
+"share/man/man1" = ["doc/*.1"]
+
 [tool.setuptools.packages.find]
 include = [
     "twoping",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 description = "2ping a bi-directional ping utility"
 readme = "README.md"
-requires-python = ">=3.6"
+requires-python = ">=3.10"
 license = "MPL-2.0"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -57,3 +57,7 @@ include = [
 
 [tool.black]
 line-length = 132
+
+[build-system]
+requires = ["setuptools>=77.0.3"]
+build-backend = "setuptools.build_meta"

--- a/twoping/__init__.py
+++ b/twoping/__init__.py
@@ -7,4 +7,4 @@
 import sys
 
 __version__ = "4.6.1"
-assert sys.version_info > (3, 6)
+assert sys.version_info > (3, 10)


### PR DESCRIPTION
This installs the manpage at `{venv}/share/man/man1`, which is recognized by installers like [pipx](https://pipx.pypa.io/stable/how-pipx-works/#manual-pages) and [homebrew](https://github.com/Homebrew/brew/blob/1f55f0c01a1afe667e373e969bca234a9ddad290/Library/Homebrew/language/python.rb#L440-L443) (with [uv](https://github.com/astral-sh/uv/issues/4731) to hopefully follow soon). 

Also, I bumped `python-requires` to 3.8+, which matches the earliest Ubuntu LTS (20.04) following https://github.com/rfinnie/2ping/commit/80e9766d72a05f614e8fc581d2f6ee5c976acf59. Note that the project was no longer installable with 3.6 anyway since `setuptools` introduced experimental support for pyproject.toml in [v61](https://github.com/pypa/setuptools/commit/a70240af2c4eade71f2900cc0fba9369939b2cd4) (3.7+) and later stabilized in [v68.1](https://github.com/pypa/setuptools/commit/9ce478c5c99b1f07120240bffceb0db31f397cde) (3.8+)
